### PR TITLE
Minor cleanup after pr 3

### DIFF
--- a/src/GameDataReader.Tests/Battlefield1942/GameDataReadersTests.cs
+++ b/src/GameDataReader.Tests/Battlefield1942/GameDataReadersTests.cs
@@ -1,7 +1,6 @@
 using System;
 using FluentAssertions;
 using GameDataReader.Battlefield1942.Reader;
-using GameDataReader.Battlefield2.Reader;
 using NUnit.Framework;
 
 namespace GameDataReader.Tests.Battlefield1942;

--- a/src/GameDataReader.Tests/Battlefield2142/GameDataReadersTests.cs
+++ b/src/GameDataReader.Tests/Battlefield2142/GameDataReadersTests.cs
@@ -1,6 +1,5 @@
 using System;
 using FluentAssertions;
-using GameDataReader.Battlefield2.Reader;
 using GameDataReader.Battlefield2142.Reader;
 using NUnit.Framework;
 

--- a/src/GameDataReader/Battlefield1942/Reader/Bf1942DataReader.cs
+++ b/src/GameDataReader/Battlefield1942/Reader/Bf1942DataReader.cs
@@ -7,7 +7,8 @@ namespace GameDataReader.Battlefield1942.Reader;
 /// </summary>
 public class Bf1942DataReader : IBf1942DataReader
 {
-    private const string GameName = "Battlefield 1942", ModName = "bf1942";
+    private const string GameName = "Battlefield 1942";
+    private const string ModName = "bf1942";
     private readonly GlobalRefractorV1ConfigFile _globalConfig;
     private ProfileRefractorV1ConfigFile? _profileConfig;
 

--- a/src/GameDataReader/Battlefield2/Reader/Bf2DataReader.cs
+++ b/src/GameDataReader/Battlefield2/Reader/Bf2DataReader.cs
@@ -7,7 +7,8 @@ namespace GameDataReader.Battlefield2.Reader;
 /// </summary>
 public class Bf2DataReader : IBf2DataReader
 {
-    private const string GameName = "Battlefield 2", NameSettingKey = "LocalProfile.setGamespyNick";
+    private const string GameName = "Battlefield 2";
+    private const string NameSettingKey = "LocalProfile.setGamespyNick";
     private readonly GlobalRefractorV2ConfigFile _globalConfig;
     private ProfileRefractorV2ConfigFile? _profileConfig;
 

--- a/src/GameDataReader/Battlefield2142/Reader/Bf2142DataReader.cs
+++ b/src/GameDataReader/Battlefield2142/Reader/Bf2142DataReader.cs
@@ -7,7 +7,8 @@ namespace GameDataReader.Battlefield2142.Reader;
 /// </summary>
 public class Bf2142DataReader : IBf2142DataReader
 {
-    private const string GameName = "Battlefield 2142", NameSettingKey = "LocalProfile.setEAOnlineSubAccount";
+    private const string GameName = "Battlefield 2142";
+    private const string NameSettingKey = "LocalProfile.setEAOnlineSubAccount";
     private readonly GlobalRefractorV2ConfigFile _globalConfig;
     private ProfileRefractorV2ConfigFile? _profileConfig;
 

--- a/src/GameDataReader/BattlefieldRefractorCommon/Files/ConfigFile.cs
+++ b/src/GameDataReader/BattlefieldRefractorCommon/Files/ConfigFile.cs
@@ -8,6 +8,13 @@ namespace GameDataReader.BattlefieldRefractorCommon.Files;
 /// <typeparam name="T">The type of the config file.</typeparam>
 public abstract class ConfigFile<T>
 {
+    protected readonly string GameName;
+
+    protected ConfigFile(string gameName)
+    {
+        GameName = gameName;
+    }
+
     protected abstract string GetFilePath();
 
     protected string GetSettingValue(string settingKey)

--- a/src/GameDataReader/BattlefieldRefractorV1Common/Files/GlobalRefractorV1ConfigFile.cs
+++ b/src/GameDataReader/BattlefieldRefractorV1Common/Files/GlobalRefractorV1ConfigFile.cs
@@ -5,7 +5,6 @@ namespace GameDataReader.BattlefieldRefractorV1Common.Files;
 internal class GlobalRefractorV1ConfigFile : ConfigFile<GlobalRefractorV1ConfigFile>
 {
     private readonly string _gameName, _modName;
-    
 
     public GlobalRefractorV1ConfigFile(string gameName, string modName)
     {

--- a/src/GameDataReader/BattlefieldRefractorV1Common/Files/GlobalRefractorV1ConfigFile.cs
+++ b/src/GameDataReader/BattlefieldRefractorV1Common/Files/GlobalRefractorV1ConfigFile.cs
@@ -4,18 +4,18 @@ namespace GameDataReader.BattlefieldRefractorV1Common.Files;
 
 internal class GlobalRefractorV1ConfigFile : ConfigFile<GlobalRefractorV1ConfigFile>
 {
-    private readonly string _gameName, _modName;
+    private readonly string _modName;
 
     public GlobalRefractorV1ConfigFile(string gameName, string modName)
+        : base(gameName)
     {
-        _gameName = gameName;
         _modName = modName;
     }
-    
+
     protected override string GetFilePath()
     {
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return $@"{appData}\VirtualStore\Program Files (x86)\EA GAMES\{_gameName}\Mods\{_modName}\Settings\Profile.con";
+        return $@"{appData}\VirtualStore\Program Files (x86)\EA GAMES\{GameName}\Mods\{_modName}\Settings\Profile.con";
     }
 
     public string GetCurrentlyActiveProfileName()

--- a/src/GameDataReader/BattlefieldRefractorV1Common/Files/ProfileRefractorV1ConfigFile.cs
+++ b/src/GameDataReader/BattlefieldRefractorV1Common/Files/ProfileRefractorV1ConfigFile.cs
@@ -4,7 +4,8 @@ namespace GameDataReader.BattlefieldRefractorV1Common.Files;
 
 public class ProfileRefractorV1ConfigFile : ConfigFile<ProfileRefractorV1ConfigFile>
 {
-    private readonly string _modName, _profileName;
+    private readonly string _modName;
+    private readonly string _profileName;
 
     public ProfileRefractorV1ConfigFile(string gameName, string modName, string profileName)
         : base(gameName)

--- a/src/GameDataReader/BattlefieldRefractorV1Common/Files/ProfileRefractorV1ConfigFile.cs
+++ b/src/GameDataReader/BattlefieldRefractorV1Common/Files/ProfileRefractorV1ConfigFile.cs
@@ -4,11 +4,11 @@ namespace GameDataReader.BattlefieldRefractorV1Common.Files;
 
 public class ProfileRefractorV1ConfigFile : ConfigFile<ProfileRefractorV1ConfigFile>
 {
-    private readonly string _gameName, _modName, _profileName;
+    private readonly string _modName, _profileName;
 
     public ProfileRefractorV1ConfigFile(string gameName, string modName, string profileName)
+        : base(gameName)
     {
-        _gameName = gameName;
         _modName = modName;
         _profileName = profileName;
     }
@@ -16,7 +16,7 @@ public class ProfileRefractorV1ConfigFile : ConfigFile<ProfileRefractorV1ConfigF
     protected override string GetFilePath()
     {
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return $@"{appData}\VirtualStore\Program Files (x86)\EA GAMES\{_gameName}\Mods\{_modName}\Settings\Profiles\{_profileName}\GeneralOptions.con";
+        return $@"{appData}\VirtualStore\Program Files (x86)\EA GAMES\{GameName}\Mods\{_modName}\Settings\Profiles\{_profileName}\GeneralOptions.con";
     }
 
     public string GetPlayerName()

--- a/src/GameDataReader/BattlefieldRefractorV2Common/Files/GlobalRefractorV2ConfigFile.cs
+++ b/src/GameDataReader/BattlefieldRefractorV2Common/Files/GlobalRefractorV2ConfigFile.cs
@@ -4,17 +4,15 @@ namespace GameDataReader.BattlefieldRefractorV2Common.Files;
 
 internal class GlobalRefractorV2ConfigFile : ConfigFile<GlobalRefractorV2ConfigFile>
 {
-    private readonly string _gameName;
-
     public GlobalRefractorV2ConfigFile(string gameName)
+        : base(gameName)
     {
-        _gameName = gameName;
     }
     
     protected override string GetFilePath()
     {
         var userDocuments = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-        return $@"{userDocuments}\{_gameName}\Profiles\Global.con";
+        return $@"{userDocuments}\{GameName}\Profiles\Global.con";
     }
 
     /// <summary>

--- a/src/GameDataReader/BattlefieldRefractorV2Common/Files/ProfileRefractorV2ConfigFile.cs
+++ b/src/GameDataReader/BattlefieldRefractorV2Common/Files/ProfileRefractorV2ConfigFile.cs
@@ -4,11 +4,11 @@ namespace GameDataReader.BattlefieldRefractorV2Common.Files;
 
 internal class ProfileRefractorV2ConfigFile : ConfigFile<ProfileRefractorV2ConfigFile>
 {
-    private readonly string _gameName, _profileNumber, _nameSettingKey;
+    private readonly string _profileNumber, _nameSettingKey;
 
     public ProfileRefractorV2ConfigFile(string gameName, string profileNumber, string nameSettingKey)
+        : base(gameName)
     {
-        _gameName = gameName;
         _profileNumber = profileNumber;
         _nameSettingKey = nameSettingKey;
     }
@@ -16,7 +16,7 @@ internal class ProfileRefractorV2ConfigFile : ConfigFile<ProfileRefractorV2Confi
     protected override string GetFilePath()
     {
         var userDocuments = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-        return $@"{userDocuments}\{_gameName}\Profiles\{_profileNumber}\Profile.con";
+        return $@"{userDocuments}\{GameName}\Profiles\{_profileNumber}\Profile.con";
     }
 
     public string GetPlayerName()

--- a/src/GameDataReader/BattlefieldRefractorV2Common/Files/ProfileRefractorV2ConfigFile.cs
+++ b/src/GameDataReader/BattlefieldRefractorV2Common/Files/ProfileRefractorV2ConfigFile.cs
@@ -4,7 +4,8 @@ namespace GameDataReader.BattlefieldRefractorV2Common.Files;
 
 internal class ProfileRefractorV2ConfigFile : ConfigFile<ProfileRefractorV2ConfigFile>
 {
-    private readonly string _profileNumber, _nameSettingKey;
+    private readonly string _profileNumber;
+    private readonly string _nameSettingKey;
 
     public ProfileRefractorV2ConfigFile(string gameName, string profileNumber, string nameSettingKey)
         : base(gameName)

--- a/src/GameDataReader/BattlefieldVietnam/Reader/BfVietnamDataReader.cs
+++ b/src/GameDataReader/BattlefieldVietnam/Reader/BfVietnamDataReader.cs
@@ -7,7 +7,8 @@ namespace GameDataReader.BattlefieldVietnam.Reader;
 /// </summary>
 public class BfVietnamDataReader : IBfVietnamDataReader
 {
-    private const string GameName = "Battlefield Vietnam", ModName = "BfVietnam";
+    private const string GameName = "Battlefield Vietnam";
+    private const string ModName = "BfVietnam";
     private readonly GlobalRefractorV1ConfigFile _globalConfig;
     private ProfileRefractorV1ConfigFile? _profileConfig;
 

--- a/src/GameDataReader/GameDataReaders.cs
+++ b/src/GameDataReader/GameDataReaders.cs
@@ -7,8 +7,8 @@ namespace GameDataReader;
 
 public static class GameDataReaders
 {
-    private static readonly Lazy<IBf1942DataReader> Bf1942Singleton = new(() => new Bf1942DataReader());
     private static readonly Lazy<IBfVietnamDataReader> BfVietnamSingleton = new(() => new BfVietnamDataReader());
+    private static readonly Lazy<IBf1942DataReader> Bf1942Singleton = new(() => new Bf1942DataReader());
     private static readonly Lazy<IBf2DataReader> Bf2Singleton = new(() => new Bf2DataReader());
     private static readonly Lazy<IBf2142DataReader> Bf2142Singleton = new(() => new Bf2142DataReader());
 

--- a/src/GameDataReader/ServiceCollectionExtensions.cs
+++ b/src/GameDataReader/ServiceCollectionExtensions.cs
@@ -1,13 +1,34 @@
-﻿using GameDataReader.Battlefield2.Reader;
+﻿using GameDataReader.Battlefield1942.Reader;
+using GameDataReader.Battlefield2.Reader;
+using GameDataReader.Battlefield2142.Reader;
+using GameDataReader.BattlefieldVietnam.Reader;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GameDataReader;
 
 public static class ServiceCollectionExtensions
 {
+    public static IServiceCollection AddBfVietnamDataReader(this IServiceCollection services)
+    {
+        services.AddScoped<IBfVietnamDataReader, BfVietnamDataReader>();
+        return services;
+    }
+
+    public static IServiceCollection AddBf1942DataReader(this IServiceCollection services)
+    {
+        services.AddScoped<IBf1942DataReader, Bf1942DataReader>();
+        return services;
+    }
+
     public static IServiceCollection AddBf2DataReader(this IServiceCollection services)
     {
         services.AddScoped<IBf2DataReader, Bf2DataReader>();
+        return services;
+    }
+
+    public static IServiceCollection AddBf2142DataReader(this IServiceCollection services)
+    {
+        services.AddScoped<IBf2142DataReader, Bf2142DataReader>();
         return services;
     }
 }


### PR DESCRIPTION


I'm committing some minor cleanups after merging the [PR](https://github.com/TwitchPlaysBF2/GameDataReader/pull/3), which are mainly just taste preferences.

- Split class members into separate declarations - this is really a personal preference thing but all of the companies I've ever worked for were enforcing this rule for reasons of:
    - Point blank readability (<-- important for making bug-hunting easier)
    - Easier to detect refactoring needs
    - Easier to refactor
    - Won't make lines long
    - Won't cause as many merge-conflicts when working with others
    - Will leave Git Diffs less messy and more readable, upon changes
- Extended the service class registrations in `ServiceCollectionExtensions.cs` so that DI based environments could also inject the new services (and mock them in tests)
- Refactor `GameName` class member to config base class since it's used in every config
