### PR TITLE
BF1942 and BFV process detection and con file dynamic file path lookup

### DIFF
--- a/src/GameDataReader.Tests/Battlefield1942/GameDataReadersTests.cs
+++ b/src/GameDataReader.Tests/Battlefield1942/GameDataReadersTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Numerics;
 using FluentAssertions;
 using GameDataReader.Battlefield1942.Reader;
 using GameDataReader.Common.Refractor.V1.Files;
@@ -14,11 +13,11 @@ public class GameDataReadersTests
 
     [Explicit("Only run this test on a real Windows machine, for end-to-end testing.")]
     [Test]
-    public void ReadActivePlayer_DoesNotThrowLocally()
+    public void GameDataReaders_Bf1942_ReadActivePlayer_DoesNotThrowLocally()
     {
         var player = Bf1942DataReader.ReadActivePlayer();
 
-        Console.WriteLine($"Player Name: {player.OnlineName}");
+        Console.WriteLine($"[Bf1942_ReadActivePlayer_DoesNotThrowLocally] Player Name: {player.OnlineName}");
     }
 
     [Test]
@@ -51,7 +50,7 @@ public class GameDataReadersTests
         var globalRefractorV1ConfigFile = new GlobalRefractorV1ConfigFile(GameName, ModName);
         var filePath = globalRefractorV1ConfigFile.GetFilePath();
 
-        Console.WriteLine($"File Path: {filePath}");
+        Console.WriteLine($"[Bf1942_IsTrueProfileFileExists] File Path: {filePath}");
 
         Assert.IsTrue(File.Exists(filePath));
     }
@@ -69,7 +68,7 @@ public class GameDataReadersTests
         var profileRefractorV1ConfigFile = new ProfileRefractorV1ConfigFile(GameName, ModName, activeProfileName);
         var filePath = profileRefractorV1ConfigFile.GetFilePath();
 
-        Console.WriteLine($"File Path: {filePath}");
+        Console.WriteLine($"[Bf1942_IsTrueGeneralOptionsFileExists] File Path: {filePath}");
 
         Assert.IsTrue(File.Exists(filePath));
     }

--- a/src/GameDataReader.Tests/Battlefield1942/GameDataReadersTests.cs
+++ b/src/GameDataReader.Tests/Battlefield1942/GameDataReadersTests.cs
@@ -1,6 +1,9 @@
 using System;
+using System.IO;
+using System.Numerics;
 using FluentAssertions;
 using GameDataReader.Battlefield1942.Reader;
+using GameDataReader.Common.Refractor.V1.Files;
 using NUnit.Framework;
 
 namespace GameDataReader.Tests.Battlefield1942;
@@ -36,5 +39,36 @@ public class GameDataReadersTests
 
         bf1942DataReader1.GetHashCode().Should()
             .NotBe(bf1942DataReader2.GetHashCode());
+    }
+
+    [Test]
+    public void GameDataReaders_Bf1942_IsTrueProfileFileExists()
+    {
+        var GameName = "Battlefield 1942";
+        var ModName = "bf1942";
+
+        var globalRefractorV1ConfigFile = new GlobalRefractorV1ConfigFile(GameName, ModName);
+        var filePath = globalRefractorV1ConfigFile.GetFilePath();
+
+        Console.WriteLine($"File Path: {filePath}");
+
+        Assert.IsTrue(File.Exists(filePath));
+    }
+
+    [Test]
+    public void GameDataReaders_Bf1942_IsTrueGeneralOptionsFileExists()
+    {
+        var GameName = "Battlefield 1942";
+        var ModName = "bf1942";
+
+        var globalRefractorV1ConfigFile = new GlobalRefractorV1ConfigFile(GameName, ModName);
+        var activeProfileName = globalRefractorV1ConfigFile.GetCurrentlyActiveProfileName();
+
+        var profileRefractorV1ConfigFile = new ProfileRefractorV1ConfigFile(GameName, ModName, activeProfileName);
+        var filePath = profileRefractorV1ConfigFile.GetFilePath();
+
+        Console.WriteLine($"File Path: {filePath}");
+
+        Assert.IsTrue(File.Exists(filePath));
     }
 }

--- a/src/GameDataReader.Tests/Battlefield1942/GameDataReadersTests.cs
+++ b/src/GameDataReader.Tests/Battlefield1942/GameDataReadersTests.cs
@@ -41,6 +41,7 @@ public class GameDataReadersTests
             .NotBe(bf1942DataReader2.GetHashCode());
     }
 
+    [Explicit("Only run this test on a real Windows machine, for end-to-end testing.")]
     [Test]
     public void GameDataReaders_Bf1942_IsTrueProfileFileExists()
     {
@@ -55,6 +56,7 @@ public class GameDataReadersTests
         Assert.IsTrue(File.Exists(filePath));
     }
 
+    [Explicit("Only run this test on a real Windows machine, for end-to-end testing.")]
     [Test]
     public void GameDataReaders_Bf1942_IsTrueGeneralOptionsFileExists()
     {

--- a/src/GameDataReader.Tests/BattlefieldVietnam/GameDataReadersTests.cs
+++ b/src/GameDataReader.Tests/BattlefieldVietnam/GameDataReadersTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.IO;
 using FluentAssertions;
 using GameDataReader.BattlefieldVietnam.Reader;
+using GameDataReader.Common.Refractor.V1.Files;
 using NUnit.Framework;
 
 namespace GameDataReader.Tests.BattlefieldVietnam;
@@ -36,5 +38,36 @@ public class GameDataReadersTests
 
         bfVietnamDataReader1.GetHashCode().Should()
             .NotBe(bfVietnamDataReader2.GetHashCode());
+    }
+
+    [Test]
+    public void GameDataReaders_BfVietnam_IsTrueProfileFileExists()
+    {
+        var GameName = "Battlefield Vietnam";
+        var ModName = "BfVietnam";
+
+        var globalRefractorV1ConfigFile = new GlobalRefractorV1ConfigFile(GameName, ModName);
+        var filePath = globalRefractorV1ConfigFile.GetFilePath();
+
+        Console.WriteLine($"File Path: {filePath}");
+
+        Assert.IsTrue(File.Exists(filePath));
+    }
+
+    [Test]
+    public void GameDataReaders_BfVietnam_IsTrueGeneralOptionsFileExists()
+    {
+        var GameName = "Battlefield Vietnam";
+        var ModName = "BfVietnam";
+
+        var globalRefractorV1ConfigFile = new GlobalRefractorV1ConfigFile(GameName, ModName);
+        var activeProfileName = globalRefractorV1ConfigFile.GetCurrentlyActiveProfileName();
+
+        var profileRefractorV1ConfigFile = new ProfileRefractorV1ConfigFile(GameName, ModName, activeProfileName);
+        var filePath = profileRefractorV1ConfigFile.GetFilePath();
+
+        Console.WriteLine($"File Path: {filePath}");
+
+        Assert.IsTrue(File.Exists(filePath));
     }
 }

--- a/src/GameDataReader.Tests/BattlefieldVietnam/GameDataReadersTests.cs
+++ b/src/GameDataReader.Tests/BattlefieldVietnam/GameDataReadersTests.cs
@@ -40,6 +40,7 @@ public class GameDataReadersTests
             .NotBe(bfVietnamDataReader2.GetHashCode());
     }
 
+    [Explicit("Only run this test on a real Windows machine, for end-to-end testing.")]
     [Test]
     public void GameDataReaders_BfVietnam_IsTrueProfileFileExists()
     {
@@ -54,6 +55,7 @@ public class GameDataReadersTests
         Assert.IsTrue(File.Exists(filePath));
     }
 
+    [Explicit("Only run this test on a real Windows machine, for end-to-end testing.")]
     [Test]
     public void GameDataReaders_BfVietnam_IsTrueGeneralOptionsFileExists()
     {

--- a/src/GameDataReader.Tests/BattlefieldVietnam/GameDataReadersTests.cs
+++ b/src/GameDataReader.Tests/BattlefieldVietnam/GameDataReadersTests.cs
@@ -13,11 +13,11 @@ public class GameDataReadersTests
 
     [Explicit("Only run this test on a real Windows machine, for end-to-end testing.")]
     [Test]
-    public void ReadActivePlayer_DoesNotThrowLocally()
+    public void GameDataReaders_BfVietnam_ReadActivePlayer_DoesNotThrowLocally()
     {
         var player = BfVietnamDataReader.ReadActivePlayer();
 
-        Console.WriteLine($"Player Name: {player.OnlineName}");
+        Console.WriteLine($"[BfVietnam_ReadActivePlayer_DoesNotThrowLocally] Player Name: {player.OnlineName}");
     }
 
     [Test]
@@ -50,7 +50,7 @@ public class GameDataReadersTests
         var globalRefractorV1ConfigFile = new GlobalRefractorV1ConfigFile(GameName, ModName);
         var filePath = globalRefractorV1ConfigFile.GetFilePath();
 
-        Console.WriteLine($"File Path: {filePath}");
+        Console.WriteLine($"[BfVietnam_IsTrueProfileFileExists] File Path: {filePath}");
 
         Assert.IsTrue(File.Exists(filePath));
     }
@@ -68,7 +68,7 @@ public class GameDataReadersTests
         var profileRefractorV1ConfigFile = new ProfileRefractorV1ConfigFile(GameName, ModName, activeProfileName);
         var filePath = profileRefractorV1ConfigFile.GetFilePath();
 
-        Console.WriteLine($"File Path: {filePath}");
+        Console.WriteLine($"[BfVietnam_IsTrueGeneralOptionsFileExists] File Path: {filePath}");
 
         Assert.IsTrue(File.Exists(filePath));
     }

--- a/src/GameDataReader/Common/Files/LineBasedConfigFile.cs
+++ b/src/GameDataReader/Common/Files/LineBasedConfigFile.cs
@@ -1,4 +1,5 @@
 ﻿using GameDataReader.Common.Parsing;
+using System.Text;
 
 namespace GameDataReader.Common.Files;
 
@@ -27,7 +28,18 @@ internal abstract class LineBasedConfigFile<T> : IConfigFile
                 "Couldn't find configuration data. Is the game installed?\r\n" +
                 $"{typeof(T).FullName} not found at location: {filePath}");
 
-        var configLines = File.ReadAllLines(filePath);
+        //BF1942 and BFVietnam CON files use ANSI/windows-1252 character encoding
+        var configLines = new List<string>();
+        if (filePath.ToLower().Contains("bf1942") || filePath.ToLower().Contains("bfvietnam"))
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            configLines = File.ReadAllLines(filePath, Encoding.GetEncoding("windows-1252")).ToList();
+        }
+        else
+        {
+            configLines = File.ReadAllLines(filePath).ToList();
+        }
+
         var resolver = new LineBasedSettingResolver(configLines, GetParsePattern());
         return resolver;
     }

--- a/src/GameDataReader/Common/Refractor/V1/Files/GlobalRefractorV1ConfigFile.cs
+++ b/src/GameDataReader/Common/Refractor/V1/Files/GlobalRefractorV1ConfigFile.cs
@@ -5,22 +5,19 @@ namespace GameDataReader.Common.Refractor.V1.Files;
 internal class GlobalRefractorV1ConfigFile : RefractorConfigFile<GlobalRefractorV1ConfigFile>
 {
     private readonly string _modName;
-    private readonly string _gameProcessPath;
-    private readonly string _conFilePath;
 
     public GlobalRefractorV1ConfigFile(string gameName, string modName)
         : base(gameName)
     {
-        var utilityMethodsRefractorV1 = new UtilityMethodsRefractorV1ConfigFile();
         _modName = modName;
-        _gameProcessPath = utilityMethodsRefractorV1.GetProcessPath(_modName);
-        var conFile = $@"\Mods\{_modName}\Settings\Profile.con";
-        _conFilePath = utilityMethodsRefractorV1.GetConFilePath(conFile, _gameProcessPath, GameName);
     }
 
     public override string GetFilePath()
     {
-        return _conFilePath;
+        var gameProcessPath = RefractorV1PathResolver.GetProcessPath(_modName);
+        var conFile = $@"\Mods\{_modName}\Settings\Profile.con";
+        conFile = RefractorV1PathResolver.GetConFilePath(conFile, gameProcessPath, GameName);
+        return conFile;
     }
 
     public string GetCurrentlyActiveProfileName()

--- a/src/GameDataReader/Common/Refractor/V1/Files/GlobalRefractorV1ConfigFile.cs
+++ b/src/GameDataReader/Common/Refractor/V1/Files/GlobalRefractorV1ConfigFile.cs
@@ -5,17 +5,24 @@ namespace GameDataReader.Common.Refractor.V1.Files;
 internal class GlobalRefractorV1ConfigFile : RefractorConfigFile<GlobalRefractorV1ConfigFile>
 {
     private readonly string _modName;
+    private readonly string _gameProcessPath;
 
     public GlobalRefractorV1ConfigFile(string gameName, string modName)
         : base(gameName)
     {
+        var utilityMethodsRefractorV1 = new UtilityMethodsRefractorV1ConfigFile();
         _modName = modName;
+        _gameProcessPath = utilityMethodsRefractorV1.GetProcessPath(_modName);
     }
 
     public override string GetFilePath()
     {
+        var profileFile = $@"\Mods\{_modName}\Settings\Profile.con";
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return $@"{appData}\VirtualStore\Program Files (x86)\EA GAMES\{GameName}\Mods\{_modName}\Settings\Profile.con";
+        var filePath = !string.IsNullOrWhiteSpace(_gameProcessPath) ?
+            $@"{_gameProcessPath}{profileFile}" :
+            $@"{appData}\VirtualStore\Program Files (x86)\EA GAMES\{GameName}{profileFile}";
+        return filePath;
     }
 
     public string GetCurrentlyActiveProfileName()

--- a/src/GameDataReader/Common/Refractor/V1/Files/GlobalRefractorV1ConfigFile.cs
+++ b/src/GameDataReader/Common/Refractor/V1/Files/GlobalRefractorV1ConfigFile.cs
@@ -14,9 +14,8 @@ internal class GlobalRefractorV1ConfigFile : RefractorConfigFile<GlobalRefractor
 
     public override string GetFilePath()
     {
-        var gameProcessPath = RefractorV1PathResolver.GetProcessPath(_modName);
         var conFile = $@"\Mods\{_modName}\Settings\Profile.con";
-        conFile = RefractorV1PathResolver.GetConFilePath(conFile, gameProcessPath, GameName);
+        conFile = RefractorV1PathResolver.GetConFilePath(conFile, _modName, GameName);
         return conFile;
     }
 

--- a/src/GameDataReader/Common/Refractor/V1/Files/GlobalRefractorV1ConfigFile.cs
+++ b/src/GameDataReader/Common/Refractor/V1/Files/GlobalRefractorV1ConfigFile.cs
@@ -6,6 +6,7 @@ internal class GlobalRefractorV1ConfigFile : RefractorConfigFile<GlobalRefractor
 {
     private readonly string _modName;
     private readonly string _gameProcessPath;
+    private readonly string _conFilePath;
 
     public GlobalRefractorV1ConfigFile(string gameName, string modName)
         : base(gameName)
@@ -13,16 +14,13 @@ internal class GlobalRefractorV1ConfigFile : RefractorConfigFile<GlobalRefractor
         var utilityMethodsRefractorV1 = new UtilityMethodsRefractorV1ConfigFile();
         _modName = modName;
         _gameProcessPath = utilityMethodsRefractorV1.GetProcessPath(_modName);
+        var conFile = $@"\Mods\{_modName}\Settings\Profile.con";
+        _conFilePath = utilityMethodsRefractorV1.GetConFilePath(conFile, _gameProcessPath, GameName);
     }
 
     public override string GetFilePath()
     {
-        var profileFile = $@"\Mods\{_modName}\Settings\Profile.con";
-        var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var filePath = !string.IsNullOrWhiteSpace(_gameProcessPath) ?
-            $@"{_gameProcessPath}{profileFile}" :
-            $@"{appData}\VirtualStore\Program Files (x86)\EA GAMES\{GameName}{profileFile}";
-        return filePath;
+        return _conFilePath;
     }
 
     public string GetCurrentlyActiveProfileName()

--- a/src/GameDataReader/Common/Refractor/V1/Files/ProfileRefractorV1ConfigFile.cs
+++ b/src/GameDataReader/Common/Refractor/V1/Files/ProfileRefractorV1ConfigFile.cs
@@ -6,18 +6,25 @@ internal class ProfileRefractorV1ConfigFile : RefractorConfigFile<ProfileRefract
 {
     private readonly string _modName;
     private readonly string _profileName;
+    private readonly string _gameProcessPath;
 
     public ProfileRefractorV1ConfigFile(string gameName, string modName, string profileName)
         : base(gameName)
     {
+        var utilityMethodsRefractorV1 = new UtilityMethodsRefractorV1ConfigFile();
         _modName = modName;
         _profileName = profileName;
+        _gameProcessPath = utilityMethodsRefractorV1.GetProcessPath(_modName);
     }
 
     public override string GetFilePath()
     {
+        var generalOptionsFile = $@"\Mods\{ _modName}\Settings\Profiles\{ _profileName}\GeneralOptions.con";
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return $@"{appData}\VirtualStore\Program Files (x86)\EA GAMES\{GameName}\Mods\{_modName}\Settings\Profiles\{_profileName}\GeneralOptions.con";
+        var filePath = !string.IsNullOrWhiteSpace(_gameProcessPath) ?
+            $@"{_gameProcessPath}{generalOptionsFile}" :
+            $@"{appData}\VirtualStore\Program Files (x86)\EA GAMES\{GameName}{generalOptionsFile}";
+        return filePath;
     }
 
     public string GetPlayerName()

--- a/src/GameDataReader/Common/Refractor/V1/Files/ProfileRefractorV1ConfigFile.cs
+++ b/src/GameDataReader/Common/Refractor/V1/Files/ProfileRefractorV1ConfigFile.cs
@@ -16,9 +16,8 @@ internal class ProfileRefractorV1ConfigFile : RefractorConfigFile<ProfileRefract
 
     public override string GetFilePath()
     {
-        var gameProcessPath = RefractorV1PathResolver.GetProcessPath(_modName);
         var conFile = $@"\Mods\{_modName}\Settings\Profiles\{_profileName}\GeneralOptions.con";
-        conFile = RefractorV1PathResolver.GetConFilePath(conFile, gameProcessPath, GameName);
+        conFile = RefractorV1PathResolver.GetConFilePath(conFile, _modName, GameName);
         return conFile;
     }
 

--- a/src/GameDataReader/Common/Refractor/V1/Files/ProfileRefractorV1ConfigFile.cs
+++ b/src/GameDataReader/Common/Refractor/V1/Files/ProfileRefractorV1ConfigFile.cs
@@ -6,23 +6,20 @@ internal class ProfileRefractorV1ConfigFile : RefractorConfigFile<ProfileRefract
 {
     private readonly string _modName;
     private readonly string _profileName;
-    private readonly string _gameProcessPath;
-    private readonly string _conFilePath;
 
     public ProfileRefractorV1ConfigFile(string gameName, string modName, string profileName)
         : base(gameName)
     {
-        var utilityMethodsRefractorV1 = new UtilityMethodsRefractorV1ConfigFile();
         _modName = modName;
         _profileName = profileName;
-        _gameProcessPath = utilityMethodsRefractorV1.GetProcessPath(_modName);
-        var conFile = $@"\Mods\{_modName}\Settings\Profiles\{_profileName}\GeneralOptions.con";
-        _conFilePath = utilityMethodsRefractorV1.GetConFilePath(conFile, _gameProcessPath, GameName);
     }
 
     public override string GetFilePath()
     {
-        return _conFilePath;
+        var gameProcessPath = RefractorV1PathResolver.GetProcessPath(_modName);
+        var conFile = $@"\Mods\{_modName}\Settings\Profiles\{_profileName}\GeneralOptions.con";
+        conFile = RefractorV1PathResolver.GetConFilePath(conFile, gameProcessPath, GameName);
+        return conFile;
     }
 
     public string GetPlayerName()

--- a/src/GameDataReader/Common/Refractor/V1/Files/ProfileRefractorV1ConfigFile.cs
+++ b/src/GameDataReader/Common/Refractor/V1/Files/ProfileRefractorV1ConfigFile.cs
@@ -7,6 +7,7 @@ internal class ProfileRefractorV1ConfigFile : RefractorConfigFile<ProfileRefract
     private readonly string _modName;
     private readonly string _profileName;
     private readonly string _gameProcessPath;
+    private readonly string _conFilePath;
 
     public ProfileRefractorV1ConfigFile(string gameName, string modName, string profileName)
         : base(gameName)
@@ -15,16 +16,13 @@ internal class ProfileRefractorV1ConfigFile : RefractorConfigFile<ProfileRefract
         _modName = modName;
         _profileName = profileName;
         _gameProcessPath = utilityMethodsRefractorV1.GetProcessPath(_modName);
+        var conFile = $@"\Mods\{_modName}\Settings\Profiles\{_profileName}\GeneralOptions.con";
+        _conFilePath = utilityMethodsRefractorV1.GetConFilePath(conFile, _gameProcessPath, GameName);
     }
 
     public override string GetFilePath()
     {
-        var generalOptionsFile = $@"\Mods\{ _modName}\Settings\Profiles\{ _profileName}\GeneralOptions.con";
-        var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var filePath = !string.IsNullOrWhiteSpace(_gameProcessPath) ?
-            $@"{_gameProcessPath}{generalOptionsFile}" :
-            $@"{appData}\VirtualStore\Program Files (x86)\EA GAMES\{GameName}{generalOptionsFile}";
-        return filePath;
+        return _conFilePath;
     }
 
     public string GetPlayerName()

--- a/src/GameDataReader/Common/Refractor/V1/Files/RefractorV1PathResolver.cs
+++ b/src/GameDataReader/Common/Refractor/V1/Files/RefractorV1PathResolver.cs
@@ -4,15 +4,15 @@ using System.Text;
 
 namespace GameDataReader.Common.Refractor.V1.Files;
 
-internal class UtilityMethodsRefractorV1ConfigFile
+internal static class RefractorV1PathResolver
 {
-    public string GetProcessPath(string modName)
+    public static string GetProcessPath(string modName)
     {
         var matchingProcesses = Process.GetProcessesByName(modName);
         return matchingProcesses.Length == 1 ? matchingProcesses[0].GetMainModuleFileName(modName) : string.Empty;
     }
 
-    public string GetConFilePath(string conFile, string gameProcessPath, string gameName)
+    public static string GetConFilePath(string conFile, string gameProcessPath, string gameName)
     {
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         var executingPath = File.Exists($@"{gameProcessPath}{conFile}") ? $@"{gameProcessPath}{conFile}" : string.Empty;

--- a/src/GameDataReader/Common/Refractor/V1/Files/RefractorV1PathResolver.cs
+++ b/src/GameDataReader/Common/Refractor/V1/Files/RefractorV1PathResolver.cs
@@ -39,22 +39,21 @@ public static class RefractorV1PathResolver
         {
             // Since BF1942 and BFV are 32bit games, the game's install path needs to be read from Wow6432Node
             var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32);
-            var registryPath = $@"SOFTWARE\EA GAMES\{gameName}";
+            var registryPath = $@"SOFTWARE\Wow6432Node\EA GAMES\{gameName}";
 
-            baseKey.OpenSubKey(registryPath);
-            if (baseKey.SubKeyCount > 0)
+            baseKey = baseKey.OpenSubKey(registryPath);
+
+            var value = baseKey?.GetValue("GAMEDIR");
+            if (value != null && !string.IsNullOrWhiteSpace(value.ToString()))
             {
-                var value = baseKey.GetValue("GAMEDIR");
-                if (value != null && !string.IsNullOrWhiteSpace(value.ToString()))
+                conFilePath = $@"{value}{conFile}";
+                if (File.Exists(conFilePath))
                 {
-                    conFilePath = Path.Combine(value.ToString(), conFile);
-                    if (File.Exists(conFilePath))
-                    {
-                        return conFilePath;
-                    }
+                    return conFilePath;
                 }
             }
 
+            conFilePath = string.Empty;
             return conFilePath;
         }
         catch (Exception)
@@ -70,17 +69,16 @@ public static class RefractorV1PathResolver
         var foundProcess = Process.GetProcessesByName(processName).FirstOrDefault();
         if (foundProcess?.MainModule != null)
         {
-            conFilePath = foundProcess.MainModule.FileName;
+            conFilePath = Path.GetDirectoryName(foundProcess.MainModule.FileName);
         }
 
-        conFilePath = Path.Combine(conFilePath, conFile);
+        conFilePath = $@"{conFilePath}{conFile}";
         if (File.Exists(conFilePath))
         {
             return conFilePath;
         }
 
         conFilePath = string.Empty;
-
         return conFilePath;
     }
 
@@ -89,14 +87,13 @@ public static class RefractorV1PathResolver
         var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 
         // Since BF1942 and BFV are 32bit games, the game's AppData path needs to be read from Program Files (x86)
-        var conFilePath = Path.Combine(appDataPath, "\\VirtualStore\\Program Files (x86)\\EA GAMES\\", gameName, conFile);
+        var conFilePath = $@"{appDataPath}\VirtualStore\Program Files (x86)\EA GAMES\{gameName}{conFile}";
         if (File.Exists(conFilePath))
         {
             return conFilePath;
         }
 
         conFilePath = string.Empty;
-
         return conFilePath;
     }
 }

--- a/src/GameDataReader/Common/Refractor/V1/Files/RefractorV1PathResolver.cs
+++ b/src/GameDataReader/Common/Refractor/V1/Files/RefractorV1PathResolver.cs
@@ -1,35 +1,105 @@
-﻿using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Text;
+﻿using Microsoft.Win32;
+using System.Diagnostics;
 
 namespace GameDataReader.Common.Refractor.V1.Files;
 
-internal static class RefractorV1PathResolver
+public static class RefractorV1PathResolver
 {
-    public static string GetProcessPath(string modName)
+    public static string GetConFilePath(string conFile, string modName, string gameName)
     {
-        var matchingProcesses = Process.GetProcessesByName(modName);
-        return matchingProcesses.Length == 1 ? matchingProcesses[0].GetMainModuleFileName(modName) : string.Empty;
+        // Use the path from the Registry, if the con file exists within the game installation path
+        var conFilePath = GetPathFromRegistry(gameName);
+        if (File.Exists(conFilePath))
+        {
+            return conFilePath;
+        }
+
+        // Use the path from the game process, if the con file exists within the game process path
+        conFilePath = GetPathFromGameProcess(conFile, modName);
+        if (File.Exists(conFilePath))
+        {
+            return conFilePath;
+        }
+
+        // Use the path from AppData, if the con file exists within the AppData path
+        conFilePath = GetPathFromAppData(conFile, gameName);
+        if (File.Exists(conFilePath))
+        {
+            return conFilePath;
+        }
+
+        return string.Empty;
     }
 
-    public static string GetConFilePath(string conFile, string gameProcessPath, string gameName)
+    public static string GetPathFromRegistry(string gameName)
     {
-        var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var executingPath = File.Exists($@"{gameProcessPath}{conFile}") ? $@"{gameProcessPath}{conFile}" : string.Empty;
-        var fallbackPath = File.Exists($@"{appData}\VirtualStore\Program Files (x86)\EA GAMES\{gameName}{conFile}") ? $@"{appData}\VirtualStore\Program Files (x86)\EA GAMES\{gameName}{conFile}" : string.Empty;
-        return File.Exists($@"{gameProcessPath}{conFile}") ? executingPath : fallbackPath;
+        var conFilePath = string.Empty;
+
+        try
+        {
+            // If the Operating System is 64bit, then the game's install path needs to be read from Wow6432Node 
+            var registryView = Environment.Is64BitOperatingSystem ? RegistryView.Registry32 : RegistryView.Default;
+            var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, registryView);
+            var registryPath = $@"SOFTWARE\EA GAMES\{gameName}";
+
+            baseKey.OpenSubKey(registryPath);
+            if (baseKey.SubKeyCount > 0)
+            {
+                var value = baseKey.GetValue("GAMEDIR");
+                if (value != null)
+                {
+                    conFilePath = value.ToString();
+                }
+            }
+
+            return conFilePath;
+        }
+        catch (Exception)
+        {
+            return conFilePath;
+        }
     }
-}
 
-internal static class Extensions
-{
-    [DllImport("Kernel32.dll")]
-    private static extern bool QueryFullProcessImageName([In] IntPtr hProcess, [In] uint dwFlags, [Out] StringBuilder lpExeName, [In, Out] ref uint lpdwSize);
-
-    public static string GetMainModuleFileName(this Process process, string modName, int buffer = 1024)
+    public static string GetPathFromGameProcess(string conFile, string processName)
     {
-        var fileNameBuilder = new StringBuilder(buffer);
-        var bufferLength = (uint)fileNameBuilder.Capacity + 1;
-        return (QueryFullProcessImageName(process.Handle, 0, fileNameBuilder, ref bufferLength) ? Path.GetDirectoryName(fileNameBuilder.ToString()) : string.Empty) ?? string.Empty;
+        var conFilePath = string.Empty;
+
+        var foundProcess = Process.GetProcessesByName(processName).FirstOrDefault();
+        var processPath = foundProcess?.MainModule?.FileName;
+
+        if (!string.IsNullOrWhiteSpace(processPath))
+        {
+            conFilePath = Path.Combine(processPath, conFile);
+            if (File.Exists(conFilePath))
+            {
+               return conFilePath;
+            }
+        }
+
+        return conFilePath;
+    }
+
+    public static string GetPathFromAppData(string conFile, string gameName)
+    {
+        var conFilePath = string.Empty;
+
+        var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (!string.IsNullOrWhiteSpace(appDataPath))
+        {
+            // Use the 32bit Operating System AppData path by default and override the AppData path if is the Operating System is 64bit
+            conFilePath = Path.Combine(appDataPath, "\\VirtualStore\\Program Files\\EA GAMES\\");
+            if (Environment.Is64BitOperatingSystem)
+            {
+                conFilePath = Path.Combine(appDataPath, "\\VirtualStore\\Program Files (x86)\\EA GAMES\\");
+            }
+
+            conFilePath = Path.Combine(conFilePath, gameName, conFile);
+            if (File.Exists(conFilePath))
+            {
+                return conFilePath;
+            }
+        }
+
+        return conFilePath;
     }
 }

--- a/src/GameDataReader/Common/Refractor/V1/Files/UtilityMethodsRefractorV1ConfigFile.cs
+++ b/src/GameDataReader/Common/Refractor/V1/Files/UtilityMethodsRefractorV1ConfigFile.cs
@@ -1,0 +1,27 @@
+﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace GameDataReader.Common.Refractor.V1.Files;
+
+internal class UtilityMethodsRefractorV1ConfigFile
+{
+    public string GetProcessPath(string modName)
+    {
+        var matchingProcesses = Process.GetProcessesByName(modName);
+        return matchingProcesses.Length == 1 ? matchingProcesses[0].GetMainModuleFileName(modName) : string.Empty;
+    }
+}
+
+internal static class Extensions
+{
+    [DllImport("Kernel32.dll")]
+    private static extern bool QueryFullProcessImageName([In] IntPtr hProcess, [In] uint dwFlags, [Out] StringBuilder lpExeName, [In, Out] ref uint lpdwSize);
+
+    public static string GetMainModuleFileName(this Process process, string modName, int buffer = 1024)
+    {
+        var fileNameBuilder = new StringBuilder(buffer);
+        var bufferLength = (uint)fileNameBuilder.Capacity + 1;
+        return (QueryFullProcessImageName(process.Handle, 0, fileNameBuilder, ref bufferLength) ? Path.GetDirectoryName(fileNameBuilder.ToString()) : string.Empty) ?? string.Empty;
+    }
+}

--- a/src/GameDataReader/Common/Refractor/V1/Files/UtilityMethodsRefractorV1ConfigFile.cs
+++ b/src/GameDataReader/Common/Refractor/V1/Files/UtilityMethodsRefractorV1ConfigFile.cs
@@ -11,6 +11,14 @@ internal class UtilityMethodsRefractorV1ConfigFile
         var matchingProcesses = Process.GetProcessesByName(modName);
         return matchingProcesses.Length == 1 ? matchingProcesses[0].GetMainModuleFileName(modName) : string.Empty;
     }
+
+    public string GetConFilePath(string conFile, string gameProcessPath, string gameName)
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var executingPath = File.Exists($@"{gameProcessPath}{conFile}") ? $@"{gameProcessPath}{conFile}" : string.Empty;
+        var fallbackPath = File.Exists($@"{appData}\VirtualStore\Program Files (x86)\EA GAMES\{gameName}{conFile}") ? $@"{appData}\VirtualStore\Program Files (x86)\EA GAMES\{gameName}{conFile}" : string.Empty;
+        return File.Exists($@"{gameProcessPath}{conFile}") ? executingPath : fallbackPath;
+    }
 }
 
 internal static class Extensions

--- a/src/GameDataReader/GameDataReader.csproj
+++ b/src/GameDataReader/GameDataReader.csproj
@@ -18,6 +18,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
         <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
     </ItemGroup>
 

--- a/src/GameDataReader/GameDataReader.csproj
+++ b/src/GameDataReader/GameDataReader.csproj
@@ -18,6 +18,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+        <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
**Recently, I installed Battlefield Rich Presence and noticed that it did not show game info in Discord while playing BF1942 and BFV.  I cloned the repos for Battlefield Rich Presence and GameDataReader and debugged the code to figure out what was happening.**


**BF1942 had the following Battlefield Rich Presence issue that prevented game information from displaying in my profile in Discord.**

**Issue:** Battlefield Rich Presence was not able to find the BF1942 game process using a RegEx to find the running process.

**Fix:** I modified Battlefield Rich Presence to look for any processes named "BF1942" and if one match is found then a GameInfo object will be returned from the IsRunning method.

**Testing:** After the fix above was applied to Battlefield Rich Presence, I built a debug version of Battlefield Rich Presence and ran BF1942 again.  This time when BF1942 was run, Battlefield Rich Presence was displayed in my Discord profile.  However, it only displayed the "In the menus" status in my profile.  When I debugged the Battlefield Rich Presence further, I was able to determine that GameDataReader was passing back the message "Couldn't find configuration data. Is the game installed?" to Battlefield Rich Presence.  This is what led me to debug the GameDataReader code.


**BF1942 and BFV each had the GameDataReader issue below that was causing the con files for each game to not be found correctly.**

**Issue:** GameDataReader was not able to find the GeneralOptions.con and Profile.con files located within the "mods\bf1942\settings" and "Mods\BfVietnam\settings" folders in each game install folder.  GameDataReader was looking in the "%LOCALAPPDATA%\VirtualStore\Program Files (x86)\EA Games\Battlefield 1942\Mods\bf1942\settings" and "%LOCALAPPDATA%\VirtualStore\Program Files (x86)\EA Games\Battlefield Vietnam\Mods\BfVietnam\settings" folders for each game.  These folders are used when BF1942 or BFV are installed under Program Files (x86) and the game does not have permission to write to the game install folder.  However, when BF1942 or BFV is not installed under Program Files (x86) each game uses the "mods\bf1942\settings" or "Mods\BfVietnam\settings" located in that game's install folder.

**Fix:** I modified GameDataReader to dynamically lookup the path where the BF1942 or BFV processes are running from.
Those paths are then used to check if the GeneralOptions.con and Profile.con files exist within the "mods\bf1942\settings" and "Mods\BfVietnam\settings" folders in each game install folder.
If the GeneralOptions.con and Profile.con files are not found, then GameDataReader will check for the existence of the con files in the "%LOCALAPPDATA%\VirtualStore\Program Files (x86)\EA Games\" for each game.

**Testing:** After the fix above was applied to GameDataReader, I built a debug version of GameDataReader and then copied the GameDataReader DLL to the debug folder for Battlefield Rich Presence.  I then ran Battlefield Rich Presence and also launched BF1942 and connected to a multiplayer server.  Battlefield Rich Presence then correctly displayed the game and server information in my Discord profile.  I repeated the same test for BFV and Battlefield Rich Presence also displayed the game and server information in Discord.


**Note:** The fix I created for Battlefield Rich Presence is dependent upon the fix for GameDataReader.
In each program I have created my fixes in a branch called **"bf1492-bfv-fixes"**.
I have submitted pull requests on both the Battlefield Rich Presence and GameDataReader GitHub repo pages.


Below are screenshots of Battlefield Rich Presence displaying game information in Discord for Battlefield 1942 and Battlefield Vietnam.

**Battlefield 1942**
![BattlefieldRichPresence-BF1942](https://user-images.githubusercontent.com/481352/221685296-d3b1b08e-e05e-4aea-9320-9016c99bd417.jpg)

**Battlefield Vietnam**
![BattlefieldRichPresence-BFV](https://user-images.githubusercontent.com/481352/221685298-7933496f-f885-42d3-a50d-211d9e24b085.jpg)


**Hopefully, the above information has been helpful in explaining the issues that were fixed in each program.  Please let me know if more information is needed.**