### PR TITLE
fix: allow % between key and value in BFBC2 GameSettings.bin

### DIFF
--- a/src/GameDataReader/BattlefieldBadCompany2/Parsing/BinSettingResolver.cs
+++ b/src/GameDataReader/BattlefieldBadCompany2/Parsing/BinSettingResolver.cs
@@ -23,7 +23,7 @@ internal class BinSettingResolver : ISettingResolver
          * a pattern of [key]...stuff...[value] emerges. We need to ignore some keys for which there are no (readable) values,
          * such as FlashValues, UIMenuTrackerPage_Store, UIMenuTrackerPage_MenuUnlocks etc.
          */
-        var regex = new Regex($@"(?<{Constants.RegexKeyGroupName}>[a-zA-Z][\w]+)(?<!UIMenu\w+|FlashValues)[\x00-\x1F\x7f-\x9f\u2122\ufffd\s]+(?<{Constants.RegexValueGroupName}>[\x20-\x7e]+)");
+        var regex = new Regex($@"(?<{Constants.RegexKeyGroupName}>[a-zA-Z][\w]+)(?<!UIMenu\w+|FlashValues)[\x00-\x1F\x7f-\x9f\u2122\ufffd\s%]+(?<{Constants.RegexValueGroupName}>[\x20-\x7e]+)");
         foreach (Match match in regex.Matches(_configContent))
         {
             var key = match.Groups[Constants.RegexKeyGroupName].Value;


### PR DESCRIPTION
When using Project Rome with Bad Company 2, there will/might be a percent symbol between the setting key and value. The `%` breaks the current key-value regex, because `%` is treated as a value. The actual value then gets matched as the next key, breaking matching for all key-value pairs behind the `%`.

Example: `AccountSavedToken\u0000%\u0000\u0000\u0000[token redacted]`.