### PR TITLE
fix: stop using regex to parse BFBC2 GameSettings.bin

### DIFF
--- a/src/GameDataReader/BattlefieldBadCompany2/Files/BfBc2BinFile.cs
+++ b/src/GameDataReader/BattlefieldBadCompany2/Files/BfBc2BinFile.cs
@@ -6,6 +6,8 @@ namespace GameDataReader.BattlefieldBadCompany2.Files;
 
 internal class BfBc2BinFile : IConfigFile
 {
+    private static readonly byte[] Header = { 0x08, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x0d, 0x00, 0x00, 0x00 };
+    
     public string GetFilePath()
     {
         var userDocuments = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
@@ -28,7 +30,27 @@ internal class BfBc2BinFile : IConfigFile
                 "Couldn't find configuration data. Is the game installed?\r\n" +
                 $"{GetType().FullName} not found at location: {filePath}");
 
-        var content = File.ReadAllText(filePath);
+        // Open file in a way that allows the game to have the file open at the same time
+        var stream = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);;
+        var reader = new BinaryReader(stream);
+        
+        // First 12 header bytes seem static
+        var header = reader.ReadBytes(12);
+        if (header.Equals(Header))
+        {
+            throw new GameDataReaderException(message:
+                $"Invalid file header: {BitConverter.ToString(header).Replace("-", " ").ToLower()}");
+        }
+        
+        // Next 4 bytes indicate the file content length
+        var length = reader.ReadInt32();
+        var content = reader.ReadBytes(length);
+        if (content.Length != length)
+        {
+            throw new GameDataReaderException(message:
+                $"Expected file to have {length} bytes, got {content.Length}");
+        }
+        
         var resolver = new BinSettingResolver(content);
         return resolver;
     }

--- a/src/GameDataReader/BattlefieldBadCompany2/Parsing/BinSettingResolver.cs
+++ b/src/GameDataReader/BattlefieldBadCompany2/Parsing/BinSettingResolver.cs
@@ -1,14 +1,13 @@
-﻿using System.Text.RegularExpressions;
-using GameDataReader.Common;
+﻿using System.Text;
 using GameDataReader.Common.Parsing;
 
 namespace GameDataReader.BattlefieldBadCompany2.Parsing;
 
 internal class BinSettingResolver : ISettingResolver
 {
-    private readonly string _configContent;
+    private readonly byte[] _configContent;
 
-    public BinSettingResolver(string configContent)
+    public BinSettingResolver(byte[] configContent)
     {
         _configContent = configContent;
     }
@@ -18,26 +17,49 @@ internal class BinSettingResolver : ISettingResolver
     /// </summary>
     public ISetting GetSetting(string settingKey)
     {
-        /*
-         * Since GameSettings.bin is a binary file, there is lots of unreadable stuff in there. But through all that,
-         * a pattern of [key]...stuff...[value] emerges. We need to ignore some keys for which there are no (readable) values,
-         * such as FlashValues, UIMenuTrackerPage_Store, UIMenuTrackerPage_MenuUnlocks etc.
-         */
-        var regex = new Regex($@"(?<{Constants.RegexKeyGroupName}>[a-zA-Z][\w]+)(?<!UIMenu\w+|FlashValues)[\x00-\x1F\x7f-\x9f\u2122\ufffd\s]+(?<{Constants.RegexValueGroupName}>[\x20-\x7e]+)");
-        foreach (Match match in regex.Matches(_configContent))
-        {
-            var key = match.Groups[Constants.RegexKeyGroupName].Value;
-            var value = match.Groups[Constants.RegexValueGroupName].Value;
-            
-            if (key != settingKey)
-                continue;
+        var stream = new MemoryStream(_configContent);
+        var reader = new BinaryReader(stream);
 
-            return new BinSetting(value);
+        // File content is split into sections, which can and will be empty
+        while (reader.BaseStream.Length - reader.BaseStream.Position >= 4)
+        {
+            // Each section starts with a 4-byte integer indicating the number of contained key-value pairs
+            var n = reader.ReadUInt32();
+
+            for (var i = 0; i < n; i++)
+            {
+                // Every key-value pair is prefixed with what seems to be a value type indicator
+                // 1 = float
+                // 2 = integer (signed)
+                // 3 = string
+                reader.ReadUInt32();
+
+                // Both key and value are stored as pascal strings regardless of the indicated type
+                var key = ReadPascalString(reader);
+                var value = ReadPascalString(reader);
+                
+                if (key != settingKey)
+                    continue;
+
+                return new BinSetting(value);
+            }
         }
 
         throw new GameDataReaderException(message:
             $"Couldn't find config setting: {settingKey}\r\n" +
             "Given config content was:\r\n" +
-            _configContent);
+            Encoding.UTF8.GetString(_configContent));
+    }
+
+    private static string ReadPascalString(BinaryReader reader)
+    {
+        var length = reader.ReadUInt32();
+        var bytes = reader.ReadBytes((int)length);
+        if (bytes.Length != length)
+        {
+            throw new EndOfStreamException("Unexpected EOF while reading Pascal string");
+        }
+        
+        return Encoding.UTF8.GetString(bytes, 0, (int)(length - 1));
     }
 }


### PR DESCRIPTION
Fixes the broken regex parsing by replacing it with proper binary-level parsing. The old regex stopped working with the switch to Project Rome, as some of the value length indicator bytes can now be interpreted as readable characters, which got picked up as values by regex.

For example: `AccountSavedToken\u0000%\u0000\u0000\u0000[token redacted]` was parsed as `AccountSavedToken: %`, with the actual token being parsed as the next key rather than a value.

The error handling may need some cleanup, I'm open for feedback.

supersedes #8